### PR TITLE
README edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,21 @@
 
 > ⚠️ EXPERIMENTAL [WIP] - USE AT YOUR OWN RISK ([learn more](#Disclaimers)) 
 
-## Demo
+## [**Demo**](https://lavamoat.github.io/LavaDome/packages/core/demo/)
 
 <details>
-<summary><a href="https://lavamoat.github.io/LavaDome/packages/core/demo/">https://lavamoat.github.io/LavaDome/packages/core/demo/</a></summary>
+<summary><strong>Preview</strong><i> (click to expand) </i></summary>
 <img width="670" src="./assets/img4.png" alt="LavaDome DEMO"/>
 </details>
 
 ## Usage
 
-LavaDome currently supports 
-[Vanilla](./packages/javascript) JavaScript and 
-[React](./packages/react) (and hopefully more in the future)
+**`LavaDome`** currently supports [Vanilla JavaScript](./packages/javascript) and [React](./packages/react) (with more on the way)
 
-### [Vanilla JavaScript](./packages/javascript)
+### [JavaScript](./packages/javascript)
 
 ```javascript
-import {LavaDome as LavaDomeJavaScript} from '@lavamoat/lavadome-javascript';
+import { LavaDome as LavaDomeJavaScript } from '@lavamoat/lavadome-javascript';
 
 const root = document.getElementById('root');
 const lavadome = new LavaDomeJavaScript(root);
@@ -32,186 +30,138 @@ lavadome.text(secret);
 ### [React](./packages/react)
 
 ```javascript
-import {LavaDome as LavaDomeRect} from '@lavamoat/lavadome-react';
+import { LavaDome as LavaDomeReact } from '@lavamoat/lavadome-react';
 
-function Secret({text}) {
+function Secret({ text }) {
     return <LavaDomeReact text={text} />
 }
 ```
 
 ## Develop
 
-`npm && npm install --global serve` or `yarn && yarn global add serve`
+To set up a local development build of **`LavaDome`**, clone this repo and run one of the following commands:
+
+```bash
+npm install && npm install --global serve
+```
+
+```bash
+yarn install && yarn global add serve
+```
 
 ## Motivation
 
-As of today, standards of the web do not offer a way to selectively isolate subtrees 
-of the DOM from some parties while granting access to others in a **secured manner** when 
-both parties share the same JavaScript execution environment.
+Under today's web standards, there is no established way to selectively isolate DOM subtrees in a **secured manner**. In other words, we can't control access to sections of the DOM by granting access for some parties while blocking access for others if they share the same JavaScript execution environment.
 
-In a world where we **no longer trust the code in our app**, even when is executed in the 
-same origin we consider to be trustworthy, we need to be able to present the user 
-with content we trust that other JavaScript code cannot compromise.
+We live in a world where we can **no longer trust the code in our own apps**, and same-origin execution does not guarantee safety. To secure secrets in the frontend, we must be able to present content to the user while ensuring that it cannot be compromised by JavaScript code running from the same browser.
 
 ## Example
 
 <details>
-<summary>
-    A great example would be MetaMask's "show private key" feature, where 
-    the private key can be exported by request of the user as plain text
-</summary>
+<summary>One use case for such a feature is MetaMask's "show private key" toggle, which exports the private key into plaintext upon user request. <i>(click to expand)</i></summary>
 <img width="666" src="./assets/img1.png" alt="Show private key feature by MetaMask"/>
 </details>
 
-At that stage, this sensitive content is attached to DOM
-and is fully **accessible to all entities** running in the same app.
+Currently, this sensitive content is simply attached to the DOM once it is exported, making it **fully accessible to all entities** running in the same app. That is, sections of the code that shouldn't have access to the private key could **easily extract it in plaintext**, so long as the malicious code has access to the DOM.
 
-So if some parts in the app are compromised, parts that don't have default access
-to the private key but do have access to the DOM, they could **easily steal the private key**
-from the DOM the minute it's being attached to it. 
-
-**We believe this is solvable.** Worth a shot.
+But rest assured. **We believe this is a solvable problem.**
 
 ## Solution
 
-In terms of successfully isolating DOM nodes,[ShadowDOM](https://web.dev/articles/shadowdom-v1) 
-technology comes very close to that, and although it 
-[isn't designed with security in mind](https://web.dev/articles/shadowdom-v1#:~:text=Note%3A%20Closed%20shadow%20roots%20are%20not%20very%20useful.%20Some%20developers%20will%20see%20closed%20mode%20as%20an%20artificial%20security%20feature.%20But%20let%27s%20be%20clear%2C%20it%27s%20not%20a%20security%20feature.%20Closed%20mode%20simply%20prevents%20outside%20JS%20from%20drilling%20into%20an%20element%27s%20internal%20DOM.), 
-it does a pretty good job in isolating subtrees of the DOM from the rest of it.
+The [`ShadowDom`](https://web.dev/articles/`ShadowDom`-v1) Web API enables us to isolate and encapsulate DOM nodes. Although it's [not designed as a security feature](https://web.dev/articles/`ShadowDom`-v1#:~:text=Note%3A%20Closed%20shadow%20roots%20are%20not%20very%20useful.%20Some%20developers%20will%20see%20closed%20mode%20as%20an%20artificial%20security%20feature.%20But%20let%27s%20be%20clear%2C%20it%27s%20not%20a%20security%20feature.for%20Closed%20mode%20simply%20prevents%20outside%20JS%20from%20drilling%20into%20an%20element%27s%20internal%20DOM.), `ShadowDom` works well for isolating DOM subtrees from JavaScript and CSS that's running elsewhere in the page.
 
-Therefore, we believe leveraging ShadowDOM while carefully addressing 
-[potential security gaps](https://blog.ankursundara.com/shadow-dom/), 
-**[LavaDomEncapsulation](https://github.com/lavamoat/lavadome/)** should be 
-a **security tool to join the LavaMoat toolbox** to allow developers to implement 
-frontend-only components that will aspire to only allow their code and the user to access/interact with,
-while not allow similar access to other untrusted JavaScript code in the app.
+**`LavaDome`**'s basic approach is to leverage `ShadowDom`, while carefully addressing its [potential security gaps](https://blog.ankursundara.com/shadow-dom/).
 
-> Shout-out [@arxenix](https://github.com/arxenix) for his 
-> [research](https://blog.ankursundara.com/shadow-dom/) on ShadowDOM security on top 
-> of which important security principles were implemented in LavaDome
+**[LavaDom](https://github.com/lavamoat/lavadome/)** is intended to be a **security tool in the LavaMoat toolbox** for implementing frontend-only components that exclusively allow interactions with the user and trusted code, while blocking access attempts by untrusted JavaScript and CSS code in the app.
+
+> Shout-out to [@arxenix](https://github.com/arxenix) for their [research](https://blog.ankursundara.com/shadow-dom/) into `ShadowDom` security, which provided the basis for major security improvements implemented in **`LavaDome`**.
 
 ## Goals
 
-This project follows some core principles to successfully serve the main goals of LavaDome:
+The **`LavaDome`** project follows the following core principles:
 
 ### Secure
 
-The most important part here is to make a secure solution, which is why we take ShadowDOM
-and wrap it with advanced security properties so that it's safe to present sensitive info in it.
+Our top priority is providing air-tight security. We have wrapped the `ShadowDom` API with advanced security properties to make it safe for use when presenting sensitive info.
 
 Visit [Security](#Security) to learn more about this effort.
 
 ### DX
 
-We want to achieve as simple Developer Experience as possible by:
+We strive to provide a streamlined developer experience. To this end, we will:
 
 1. Support as many popular frameworks (React, Angular, etc) as possible;
-2. Make the API as easy and simple and easy to use as possible.
+2. Make the API easy and simple to use.
 
-### Read - not write
+### Read-mode only
 
-At this stage, we're not going to support write-mode, meaning the content LavaDome
-is willing to support is plain text and nothing more complex than that.
+At this stage, we do not plan to support write-mode, meaning **`LavaDome`** will only accept plaintext content for protection, and nothing more complex than that.
 
-This is because supporting write mode - meaning an intractable isolated DOM - introduces
-multiple security complications we're not yet ready to face at this point, such as:
+This is because supporting write-mode will require implementing an intractable isolated DOM, which introduces multiple security complications that we're not yet ready to face at this point, such as:
 
-1. Event listeners security - prevent outer code from stealing input destined to 
-LavaDome inner nodes;
-2. Overlay security - prevent malicious code from laying phishing DOM on top of LavaDome,
-thus making the user serve sensitive input to the wrong entity;
-3. etc - Probably more stuff.
-
-
+1. Event listeners security - prevent outer code from intercepting input that is destined for LavaDome inner nodes.
+2. Overlay security - prevent malicious code from laying a phishing DOM on **`LavaDome`** to make the user serve sensitive input to the wrong entity.
 
 ## Design
 
-The design complexity level of this project isn't this high - it's the combination of
-the different principles in this project that make it non-trivial 
-(see [Security](#Security)).
+The design complexity of this project isn't high. However, satisfying the combined requirements of the security principles it implements is a non-trivial task (see [Security](#Security)).
 
-Nevertheless, it's worth explaining the design in high level by listing the different packages:
+**`LavaDome`** consists of the following packages:
 
 ### [Core](./packages/core)
 
-Implements the basic API layer that mediates the communication between the consumer and
-the protected isolated component. The API aspires to allow as much external manipulation
-of the isolated component as possible without providing actual DOM nodes from within it to 
-anyone - not even the consumer of LavaDome - to maintain the highest security level possible.
+Implements the basic API layer that mediates the communication between the consumer and the protected isolated component. The API aspires to allow as much external manipulation of the isolated component as possible without providing actual DOM nodes from within it to anyone - not even the consumer of LavaDome - to maintain the highest security level possible.
 
-In addition, it takes the responsibility of implementing all necessary security hardening
-to make ShadowDOM feature usage truly secure in contrast to its native nature of not
-being a security feature by default (see [Security](#Security)).
+In addition, it takes the responsibility of implementing all necessary security hardening to make `ShadowDom` feature usage truly secure in contrast to its native nature of not being a security feature by default (see [Security](#Security)).
 
 ### [JavaScript](./packages/javascript) / [React](./packages/react) / etc
 
-Export functionalities for developers to consume LavaDome however they prefer,
-whether by javascript JavaScript or as a React component 
-(or any other platform - [ask away!](https://github.com/lavamoat/lavadome/issues/new?title=LavaDome+misses+support+for+...))
+Export functionalities for developers to consume **`LavaDome`** however they prefer, whether by javascript JavaScript or as a React component (or any other platform - [ask away!](https://github.com/lavamoat/lavadome/issues/new?title=**`LavaDome`**+misses+support+for+...))
+> NOTE: Delivering **`LavaDome`** support for frameworks integrates third party code that we do not control, which causes "security blank spots".
 
-> NOTE: Delivering LavaDome support for frameworks integrates third party code
-> that is out of our control, which results in "security blank spots" - please
-> read the [Security](#Security) section to learn what to do to remain as safe as possible.
+> Please read the [Security](#Security) section to learn how to remain as safe as possible when using **`LavaDome`** with third-party frameworks.
 
 ## Security
 
-Whether you plan on using LavaDome or just interested in what we're trying to achieve here,
-these are the security aspects to be aware of
+If you plan on using **`LavaDome`** for a project, here are the security aspects to be aware of:
 
-### ShadowDOM vs iframes
+### `ShadowDom` vs `iframe`
 
-Again, this is still an experimental project, but we did put some thought into this decision.
-A natural alternative was leveraging cross-origin iframes. 
+Again, this is still an experimental project, but we did put some thought into this decision. A natural alternative to using the `ShadowDom` is leveraging cross-origin `iframe`s. Infiltrating a cross-origin `iframe` is impossible, and it is recognized as a security critical mechanism by W3C spec. This means that if a breach somehow happens, it is treated as a security vulnerability and fixed by browser vendors with urgency.
 
-The upside to those is that infiltrating a cross-origin iframe is impossible, and is recognized 
-as a security critical mechanism by W3C spec, which means that if it gets breached somehow, that 
-will be treated as a security vulnerability and will be addressed and fixed by browser vendors urgently.
+The downside to this approach, however, is that integrating an iframe-based solution is significantly more difficult, in terms of UI/UX/DX, especially as a tool aimed at mass adoption.
 
-The downside however, is that integrating an iframe-based solution is significantly harder,
-in terms of UI/UX/DX, especially as a tool aimed at mass adoption.
+**`LavaDome`** needs to provide a smooth and natural developer experience while facilitating the secure integration of encapsulated shadow DOM nodes within the host DOM tree, and `ShadowDom` is a DOM-oriented API built precisely for that purpose. This made it better-suited for our goals.
 
-Because eventually, this is about being able to integrate DOM nodes within DOM trees
-in the most natural and smooth way - ShadowDOM API is built exactly for that purpose - 
-being a DOM oriented API aimed to easily integrate within DOM trees while belonging to
-the same realm as the encapsulating DOM tree.
+While the `ShadowDom` API is not officially endorsed as a security tool by its creators, its implementation is highly secure, and it does not leak any encapsulated information from within the shadow DOM tree except under very specific scenarios.
 
-The alleged downside to the ShadowDOM API is that it isn't originally designed for security
-goals, but in reality its implementation is introduced in a highly secured manner, not
-leaking anything from within it except for very specific scenarios.
+We believe that by carefully addressing those very scenarios, `ShadowDom` can be augmented into a secured DOM encapsulation API (worth a shot).
 
-We believe that by addressing these scenarios securely and carefully, we can take ShadowDOM
-another step closer to being a secured DOM encapsulation API (worth a shot).
+### `ShadowDom` security gaps
 
-### ShadowDOM security gaps
+It's important to address the current security threats that exist with `ShadowDom`.
 
-It's important to address the current security threats that do exist with ShadowDOM.
+#### 1. Injection
 
-#### Injection
+Developers might provide **`LavaDome`** with HTML/JS/CSS content that, when loaded, can accidentally or intentionally leak DOM nodes from within the `ShadowDom`, for example by dynamically adding JavaScript code at runtime.
 
-Developers might provide LavaDome with HTML/JS/CSS content that can accidentally or
-intentionally leak DOM nodes from within the ShadowDOM when loaded, for example by
-adding JavaScript code.
+To prevent this possibility, **`LavaDome`** does not accept DOM nodes at all into the shadow DOM tree, and only supports encapsulating plain text. This lets us avoid having to grapple with the security issues inherent in trusting user-supplied HTML/JS/CSS content.
 
-In order to not allow this to happen, LavaDome does not accept DOM nodes, but merely
-plain text, as we want to avoid attempting to trust HTML/JS/CSS content.
+We'd love to revisit this decision in the future as we research a stable and secure means of supporting DOM node and subtree input.
 
-We'd love to revisit this decision in the future when we research and find a stable and
-secure way to achieve that.
+#### 2. [window.find()](https://blog.ankursundara.com/shadow-dom/#introducing-windowfind-and-text-selections)
 
-#### [window.find()](https://blog.ankursundara.com/shadow-dom/#introducing-windowfind-and-text-selections)
-
-This API allows developers to find and extract DOM nodes by finding some text inside them,
-and is the only API that is known (so far) to successfully leak DOM nodes from within a ShadowDOM.
+This API allows developers to find and extract DOM nodes by searching for text that they contain. This is the only API that has so far been known to successfully leak DOM nodes from within a `ShadowDom`.
 
 <details>
 <summary>
-    In Firefox, after finding the text, one can use <code>getSelection()</code> API to
-    leak DOM nodes from within the ShadowDOM, thus compromising the whole idea
+    In Firefox, after finding the text, one can use <code>getSelection()</code> API to leak DOM nodes from within the `ShadowDom`, thus compromising the whole idea: <i>(click to expand)</i>
 </summary>
-<pre><code>
+
+```js
 // defender
 const secret = 'AN UNPREDICTABLE SECRET';
-const opts = {mode:'closed'};
+const opts = { mode:'closed' };
 const root = document.body.firstElementChild.firstElementChild;
 const p = document.createElement('p');
 const shadow = root.attachShadow(opts);
@@ -223,29 +173,24 @@ setTimeout(() => {
     find('Secret is:'); // assuming the Shadow includes predictable text
     console.log('stolen secret: ', getSelection().anchorNode.textContent);
 });
-</code></pre>
-<img width="800" src="./assets/img2.png" alt="ShadowDOM bypass Firefox"/>
+```
+
+<img width="800" src="./assets/img2.png" alt="`ShadowDom` bypass Firefox"/>
 </details>
 
-To defend against that, for starters this means consumer of LavaDome must not
-pass predictable content to LavaDome API. This might sound obvious, but developers
-can easily be tempted to pass LavaDome something like `The secret is: ldsjf9304rjdkn`,
-but that would compromise everything, because even though the `ldsjf9304rjdkn` part clearly
-changes, the phrase `The secret is: ` can be exploited to get to the real secret.
+To defend against this attack, the **`LavaDome`** consumer must not pass predictable content to the **`LavaDome`** API. While this might sound obvious, developers could easily be tempted to pass **`LavaDome`** an input that looks something like `The secret is: ldsjf9304rjdkn`, which would fully compromise the security of **`LavaDome`**. Even though the `ldsjf9304rjdkn` part is unguessable, the fixed phrase `"The secret is: "` could be exploited to reveal the secret, especially if it was previously exposed in the DOM.
 
-Therefore, when using LavaDome, developers MUST only pass it 100% unpredictable text.
+Therefore, when using **`LavaDome`**, developers MUST only pass 100% unpredictable text as input.
 
 <details>
 <summary>
-    In Chromium, that wouldn't work, but if a selected DOM node within the ShadowDOM
-    is <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable">content-editable</a>,
-    leveraging <code>document.execCommand('insertHTML', ...)</code> can allow attackers
-    run code in the inner scope of the ShadowDOM, and use that to access its DOM nodes
+    Chromium is secure against the above attack. However, if a selected DOM node within the `ShadowDom` is <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable">content-editable</a>, attackers can leverage <code>document.execCommand('insertHTML', ...)</code> to achieve arbitrary code execution in the inner scope of the `ShadowDom`, and use that to access the encapsulated DOM nodes. <i>(click to expand)</i>
 </summary>
-<pre><code>
+
+```js
 // defender
 const secret = 'AN UNPREDICTABLE SECRET';
-const opts = {mode:'closed'};
+const opts = { mode:'closed' };
 const root = document.body.firstElementChild.firstElementChild;
 const div = document.createElement('div');
 const shadow = root.attachShadow(opts);
@@ -261,74 +206,45 @@ setTimeout(() => {
     const bypass = '<audio/src/onerror=console.log(2,this.nextSibling.innerHTML)>';
     find('Secret is:'); // assuming the Shadow includes predictable text
     // assuming the found node is contenteditable=true
-    document.execCommand("insertHTML", false, bypass);
+    document.execCommand('insertHTML', false, bypass);
 });
-</code></pre>
-<img width="800" src="./assets/img3.png" alt="ShadowDOM bypass Chromium"/>
+```
+
+<img width="800" src="./assets/img3.png" alt="`ShadowDom` bypass Chromium"/>
 </details>
 
-To defend against that, LavaDome will apply to its custom elements the highest priority
-style possible for `-webkit-user-modify: unset;` so that no elements of it are vulnerable
-to injection of malicious outer style making it contenteditable.
-Otherwise, malicious outer style applying `-webkit-user-modify:read-write` might
-make the ShadowDOM elements contenteditable and vulnerable to this attack vector.
+To defend against this attack vector, **`LavaDome`** removes all style attributes from its custom elements using the highest priority style attribute possible (`-webkit-user-modify: unset;`). This ensures that its elements are not vulnerable to injection of malicious external CSS that applies the `-webkit-user-modify:read-write` attribute, which would make `ShadowDom` elements `contenteditable`.
 
-Needless to say that the other technique of using `contenteditable` as an attribute
-isn't currently relevant as LavaDome does not support accepting actual DOM nodes by design.
+The second technique of using `contenteditable` as an attribute isn't currently relevant as **`LavaDome`** does not support accepting DOM nodes.
 
-#### Selectability
+#### 3. Selectability
 
-The attack vectors above aren't so useful if `getSelection` is mitigated.
-By making the text inside LavaDome non-selectable, we harden the security against
-possible injection as demonstrated before. This works well in Chromium but less in Firefox.
+The attack vectors above aren't so useful if `getSelection` is mitigated. By making the text contained in **`LavaDome`** non-selectable, we harden the security against possible injection as demonstrated above. This works well in Chromium but we are working out some issues with Firefox.
 
-### Secret splitting
+#### 4. Secret splitting
 
-The problem is, if an attacker manages to somehow guess a subset of the secret,
-they can compromise it entirely (assuming `getSelection` captures scoped nodes
-like in Firefox), because it will leak the text node that includes the subset
-which is in fact the entire secret.
+If an attacker manages to guess a subset of the secret, they can compromise the entire secret (assuming `getSelection` captures scoped nodes like in Firefox). This is because searching for the subset will leak the text node that includes that subset of the secret, giving the attacker access to the entire secret.
 
-To fight that off, LavaDome stores each character of the secret in a ShadowDOM
-of its own, so that compromising a subset does not compromise the rest.
+As a countermeasure, **`LavaDome`** stores each character of the secret in its own `ShadowDom`, ensuring that compromising a subset of the secret will not lead to the rest being compromised as well. This safeguard has the additional benefit of making it exponentially more difficult to attackers to leak the whole secret the longer it is and the more character options it potentially includes.
 
-This means that the longer the secret is and the more char options it may
-potentially include, it gets exponential harder for attackers to leak it all.
-
-It's still possible, because an attacker can still attempt to find all possible chars
-one by one, leak all shadows they find, and then reorder them correctly,
-according to their order within the LavaDome main host - all synchronously.
+A breach is still possible, but only if the attacker brute-forces all possible characters one by one, leaks all of the shadows they find, and then synchronously reorders all of the shadows correctly to align with their respective positions within the **`LavaDome`** main host.
 
 ### Defensive coding
 
-Hard to achieve an actual secured solution without writing the code defensively.
-This means that all the native APIs we use are cached for internal usage, so that
-it isn't possible to reconfigure global APIs to sabotage the legit flow of LavaDome.
+A secure solution requires defensive coding practices.
 
-If you see some weird code style choices in the sourcecode, there's a good chance it
-was done out of having defensive coding in mind.
+- To this end, all of the native APIs we use are cached for internal usage, to prevent attackers from reconfiguring global APIs to sabotage the execution flow of **`LavaDome`**.
 
-As long as we remain in the realms of Vanilla JavaScript, defensive coding is something
-we can (do our very best to) control.
+- If you observe unconventional stylistic choices in the source code, there's a good chance they were informed by defensive coding principles.
 
-Which is why it's **crucial** LavaDome is included in the app before any scripts
-you don't trust, preferably before ALL scripts!
+- It is **crucial** to include **`LavaDome`** in the app before any scripts you don't trust, and preferably before ALL scripts!
 
-However, when using the framework versions of LavaDome, this means these 
-frameworks aren't defensively written which means the native APIs they make use
-of aren't safe from malicious interference - and that is out of LavaDome's control.
+- When using the framework versions of **`LavaDome`**, you should assume that these frameworks are not defensively written, and that the native APIs use are not safe from malicious interference. Be warned that the security of external code is outside of **`LavaDome`**'s control.
 
-Which is why we recommend to always integrate such security solutions with 
-[SES](https://github.com/endojs/endo/tree/master/packages/ses#ses) technology by  
-[@agoric](https://github.com/agoric) - same as we do at 
-[LavaMoat](https://github.com/lavamoat/lavamoat) and 
-[MetaMask](https://github.com/MetaMask/metamask-extension).
+Therefore, we recommend always integrating such security solutions with the [SES](https://github.com/endojs/endo/tree/master/packages/ses#ses) technology developed by [@agoric](https://github.com/agoric). This is a security practice followed at [LavaMoat](https://github.com/lavamoat/lavamoat) and [MetaMask](https://github.com/MetaMask/metamask-extension).
 
-## Disclaimers
+## Disclaimer
 
-If you read everything above, you should have a good sense of why this is still very 
-experimental. Ensuring security to a non-security feature by nature is risky, and this
-project is merely an experimental attempt to solve a problem with no current great answer.
+If you read everything above, you should have a good sense of why **`LavaDome`** is still very experimental. Making a non-security feature secure is inherently risky, but as this problem space has no good existing solutions, we feel that this attempt represents a step in the right direction.
 
-You should still use it - because it's probably better than what the web has to offer currently.
-But even if it's safer than other solutions, it should not be mistaken for "safe" but rather "safer".
+We still recommend using **`LavaDome`**, as it represents an unambiguous improvement compared to relying only on current web standards. Just remember that our solution will make your code "safer," but not "safe."

--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -24,7 +24,7 @@
             }());
         </script>
     </head>
-    <body style="background-color: #FDDACD " onload="start(PRIVATE)">
+    <body style="max-width: '700px'; background-color: #FDDACD " onload="start(PRIVATE)">
         <div id="content" style="padding: 10px">
             <h1><a href="https://github.com/lavamoat/LavaDome">LavaDome</a> 🌋</h1>
             <blockquote>


### PR DESCRIPTION
- All instances of project name styled as "\*\*\`LavaDome\`\*\*" (**`LavaDome`**).
- Stylize `ShadowDom` and `iframe` with backticks.
- Prettify code blocks.
- Grammar fixes. Prefer shorter sentences and active voice.
- "*(click to expand)*" directive for details blocks.
- Group sentences into paragraphs instead of lines.
- Add numbering to security gaps headings.