### PR TITLE
Support distraction text stripping from inner secret for debug/tests

### DIFF
--- a/packages/core/demo/index.html
+++ b/packages/core/demo/index.html
@@ -25,7 +25,7 @@
                     console.log(
                         'DEMO(LavaDomeDebug):',
                         `Since 'unsafeOpenModeShadow' is ${unsafeOpenModeShadow ? 'ENABLED' : 'DISABLED'}, here's the secret:`,
-                        `'${LavaDomeDebug.getTextByRoot(root)}'`,
+                        `'${LavaDomeDebug.stripDistractionFromText(LavaDomeDebug.getTextByRoot(root))}'`,
                     );
                 }
             }());

--- a/packages/core/src/debug.mjs
+++ b/packages/core/src/debug.mjs
@@ -1,16 +1,17 @@
 import {OPTIONS} from './options.mjs';
 import {from, map} from './native.mjs';
+import {distraction} from './element.mjs';
 
-// Attempt to reconstruct LavaDome instance secret given its original root - an unsafe
+// Attempt to reconstruct LavaDome instance secret given its original root - an UNSAFE
 // method only expected to work when 'unsafeOpenModeShadow' debug-only option is enabled
 function getTextByRoot(root) {
+    console.warn('LavaDomeDebug(getTextByRoot):',
+        `Call/include this function for testing/debugging purposes only!`,
+        `(remember, '${OPTIONS.unsafeOpenModeShadow}' must be enabled for this function to work)`
+    );
+
     // will remain empty when 'unsafeOpenModeShadow' is disabled
     let text = '';
-
-    console.warn('LavaDome:',
-        `Call this function for testing/debugging purposes only!`,
-        `Remember, '${OPTIONS.unsafeOpenModeShadow}' must be enabled for this function to work`
-    );
 
     const shadow = root?.shadowRoot;
     if (!shadow) {
@@ -26,6 +27,23 @@ function getTextByRoot(root) {
     return text;
 }
 
+// Strip distraction chars from given LavaDome inner text to get a string representing
+// the inner text exactly - an UNSAFE method relevant for when testing a LavaDome node
+// with web drivers that when are asked to get its inner text capture both the secret
+// and the distraction text, which is usually irrelevant for tests
+function stripDistractionFromText(text) {
+    console.warn('LavaDomeDebug(stripDistractionFromText):',
+        `Call/include this function for testing/debugging purposes only!`,
+    );
+
+    return text
+        .split(distraction().innerText).join('')
+        .split('\n').join('')
+        .split('\r').join('')
+        .split('\t').join('');
+}
+
 export const LavaDomeDebug = {
     getTextByRoot,
+    stripDistractionFromText,
 }


### PR DESCRIPTION
Web drivers in testings envs capture the distraction text along with the secret, even though the tests expect to only find the secret.
Therefore, we now export a new function to help developers strip the distraction text from the secret obtained by the driver to test for a match successfully as before they integrated LavaDome.