### PR TITLE
Support LavaDomeDebug being required in non browser envs

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lavamoat/lavadome-core",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "description": "",
     "license": "MIT",
     "scripts": {

--- a/packages/core/src/char.mjs
+++ b/packages/core/src/char.mjs
@@ -1,0 +1,15 @@
+import {toUpperCase} from './native.mjs';
+
+const letters = 'abcdefghijklmnopqrstuvwxyz';
+const digits = '0123456789';
+const symbols = '!@#$%^&*()?.;:"\'[]{}+=-_/';
+const alphanumeric = letters + digits;
+const all = letters + toUpperCase(letters) + digits + symbols;
+
+export const chars = {
+    letters,
+    digits,
+    symbols,
+    alphanumeric,
+    all,
+};

--- a/packages/core/src/debug.mjs
+++ b/packages/core/src/debug.mjs
@@ -1,6 +1,8 @@
 import {OPTIONS} from './options.mjs';
 import {from, map} from './native.mjs';
-import {distraction} from './element.mjs';
+import {chars} from './char.mjs';
+
+const {all} = chars;
 
 // Attempt to reconstruct LavaDome instance secret given its original root - an UNSAFE
 // method only expected to work when 'unsafeOpenModeShadow' debug-only option is enabled
@@ -37,7 +39,7 @@ function stripDistractionFromText(text) {
     );
 
     return text
-        .split(distraction().innerText).join('')
+        .split(all).join('')
         .split('\n').join('')
         .split('\r').join('')
         .split('\t').join('');

--- a/packages/core/src/element.mjs
+++ b/packages/core/src/element.mjs
@@ -9,14 +9,14 @@ import {
     setAttribute,
     textContentSet,
     toFixed,
-    toUpperCase,
 } from './native.mjs';
+import {chars} from './char.mjs';
 
-const letters = 'abcdefghijklmnopqrstuvwxyz';
-const digits = '0123456789';
-const symbols = '!@#$%^&*()?.;:"\'[]{}+=-_/';
-const alphanumeric = letters + digits;
-const all = letters + toUpperCase(letters) + digits + symbols;
+const {
+    letters,
+    alphanumeric,
+    all,
+} = chars;
 
 const randChar = (f, n) => f[parseInt(toFixed(random() * n))];
 const rand = len => randChar(letters, 26) +

--- a/packages/core/src/native.mjs
+++ b/packages/core/src/native.mjs
@@ -5,7 +5,7 @@ const {
     Function, Math,
     parseInt, WeakMap,
     Error, JSON,
-} = window;
+} = globalThis;
 const {
     defineProperties, assign,
     getOwnPropertyDescriptor,
@@ -17,21 +17,21 @@ const { stringify } = JSON;
 
 // native generation util
 const n = (obj, prop, accessor) =>
-    Function.prototype.call.bind(getOwnPropertyDescriptor(obj, prop)[accessor]);
+    obj && Function.prototype.call.bind(getOwnPropertyDescriptor(obj, prop)[accessor]);
 
-export const attachShadow = n(Element.prototype, 'attachShadow', 'value');
-export const createElement = n(Document.prototype, 'createElement', 'value');
-export const appendChild = n(Node.prototype, 'appendChild', 'value');
-export const textContentSet = n(Node.prototype, 'textContent', 'set');
-export const setAttribute = n(Element.prototype, 'setAttribute', 'value');
-export const toUpperCase = n(String.prototype, 'toUpperCase', 'value');
-export const map = n(Array.prototype, 'map', 'value');
-export const join = n(Array.prototype, 'join', 'value');
-export const keys = n(Array.prototype, 'keys', 'value');
-export const at = n(Array.prototype, 'at', 'value');
-export const get = n(WeakMap.prototype, 'get', 'value');
-export const set = n(WeakMap.prototype, 'set', 'value');
-export const toFixed = n(Number.prototype, 'toFixed', 'value')
+export const attachShadow = n(globalThis?.Element?.prototype, 'attachShadow', 'value');
+export const createElement = n(globalThis?.Document?.prototype, 'createElement', 'value');
+export const appendChild = n(globalThis?.Node?.prototype, 'appendChild', 'value');
+export const textContentSet = n(globalThis?.Node?.prototype, 'textContent', 'set');
+export const setAttribute = n(globalThis?.Element?.prototype, 'setAttribute', 'value');
+export const toUpperCase = n(globalThis?.String?.prototype, 'toUpperCase', 'value');
+export const map = n(globalThis?.Array?.prototype, 'map', 'value');
+export const join = n(globalThis?.Array?.prototype, 'join', 'value');
+export const keys = n(globalThis?.Array?.prototype, 'keys', 'value');
+export const at = n(globalThis?.Array?.prototype, 'at', 'value');
+export const get = n(globalThis?.WeakMap?.prototype, 'get', 'value');
+export const set = n(globalThis?.WeakMap?.prototype, 'set', 'value');
+export const toFixed = n(globalThis?.Number?.prototype, 'toFixed', 'value')
 
 export {
     // window

--- a/packages/javascript/package.json
+++ b/packages/javascript/package.json
@@ -1,12 +1,12 @@
 {
     "name": "@lavamoat/lavadome-javascript",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "description": "",
     "license": "MIT",
     "module": "src/index.mjs",
     "main": "build/main.js",
     "dependencies": {
-        "@lavamoat/lavadome-core": "^0.0.8"
+        "@lavamoat/lavadome-core": "^0.0.9"
     },
     "scripts": {
         "build": "NODE_ENV=production LD_PKG=javascript webpack --config ../../webpack.production.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lavamoat/lavadome-react",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "description": "",
     "license": "MIT",
     "module": "src/index.mjs",
@@ -31,7 +31,7 @@
         "webpack-dev-server": "4.15.1"
     },
     "dependencies": {
-        "@lavamoat/lavadome-core": "^0.0.8"
+        "@lavamoat/lavadome-core": "^0.0.9"
     },
     "peerDependencies": {
         "react": "^16.12.0",


### PR DESCRIPTION
Last PR #20 introduced some useful debugging utils to assist testing with web drivers, but it's currently useless because it doesn't support being required in non browser env such as nodejs env - this PR fixes it.