### PR TITLE
Integrate LavaMoat allow-scripts protection

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,0 @@
-nodeLinker: node-modules

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build-javascript": "cd packages/javascript/ && npm run build && cd ..",
     "build-react": "cd packages/react/ && npm run build && cd ..",
     "build": "npm run build-core && npm run build-javascript && npm run build-react",
-    "publish": "npm publish --access=public -ws"
+    "publish": "npm publish --access=public -ws",
+    "setup": "npm install && npm run allow-scripts"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -14,12 +14,13 @@
     "publish": "npm publish --access=public -ws"
   },
   "devDependencies": {
-    "esbuild": "0.19.8",
+    "@lavamoat/allow-scripts": "^3.0.1",
     "@wdio/cli": "^8.27.0",
     "@wdio/local-runner": "^8.27.0",
     "@wdio/mocha-framework": "^8.27.0",
     "@wdio/spec-reporter": "^8.27.0",
     "chromedriver": "119.0.1",
+    "esbuild": "0.19.8",
     "geckodriver": "^4.3.0",
     "wdio-chromedriver-service": "8.1.1",
     "wdio-geckodriver-service": "^5.0.2",
@@ -35,5 +36,17 @@
   "bugs": {
     "url": "https://github.com/lavamoat/LavaDome/issues"
   },
-  "homepage": "https://github.com/lavamoat/LavaDome#readme"
+  "homepage": "https://github.com/lavamoat/LavaDome#readme",
+  "dependencies": {
+    "@lavamoat/preinstall-always-fail": "^2.0.0"
+  },
+  "lavamoat": {
+    "allowScripts": {
+      "@lavamoat/preinstall-always-fail": false,
+      "@wdio/cli>@wdio/utils>edgedriver": false,
+      "chromedriver": false,
+      "esbuild": false,
+      "geckodriver": false
+    }
+  }
 }

--- a/packages/core/.npmrc
+++ b/packages/core/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,12 +1,20 @@
 {
-    "name": "@lavamoat/lavadome-core",
-    "version": "0.0.10",
-    "description": "",
-    "license": "MIT",
-    "scripts": {
-        "demo": "serve . -l 3000",
-        "build": "NODE_ENV=production LD_PKG=core webpack --config ../../webpack.production.js"
-    },
-    "module": "src/index.mjs",
-    "main": "build/main.js"
+  "name": "@lavamoat/lavadome-core",
+  "version": "0.0.10",
+  "description": "",
+  "license": "MIT",
+  "scripts": {
+    "demo": "serve . -l 3000",
+    "build": "NODE_ENV=production LD_PKG=core webpack --config ../../webpack.production.js"
+  },
+  "module": "src/index.mjs",
+  "main": "build/main.js",
+  "dependencies": {
+    "@lavamoat/preinstall-always-fail": "^2.0.0"
+  },
+  "lavamoat": {
+    "allowScripts": {
+      "@lavamoat/preinstall-always-fail": false
+    }
+  }
 }

--- a/packages/javascript/.npmrc
+++ b/packages/javascript/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/packages/javascript/package.json
+++ b/packages/javascript/package.json
@@ -1,21 +1,27 @@
 {
-    "name": "@lavamoat/lavadome-javascript",
-    "version": "0.0.10",
-    "description": "",
-    "license": "MIT",
-    "module": "src/index.mjs",
-    "main": "build/main.js",
-    "dependencies": {
-        "@lavamoat/lavadome-core": "^0.0.10"
-    },
-    "scripts": {
-        "build": "NODE_ENV=production LD_PKG=javascript webpack --config ../../webpack.production.js",
-        "build-demo-watch": "while true; do npm run build-demo; sleep 1; done",
-        "build-demo": "../../node_modules/.bin/esbuild demo/index.js --bundle --outfile=demo/build/index.js --allow-overwrite --target=es2020",
-        "demo": "npm run build-demo && serve ./demo -l 3000",
-        "test": "npm run demo & npm run test-chrome && npm run test-firefox && npm run test-safari",
-        "test-chrome": "../../node_modules/.bin/wdio run chrome.wdio.conf.js",
-        "test-safari": "../../node_modules/.bin/wdio run safari.wdio.conf.js",
-        "test-firefox": "../../node_modules/.bin/wdio run firefox.wdio.conf.js"
+  "name": "@lavamoat/lavadome-javascript",
+  "version": "0.0.10",
+  "description": "",
+  "license": "MIT",
+  "module": "src/index.mjs",
+  "main": "build/main.js",
+  "dependencies": {
+    "@lavamoat/lavadome-core": "^0.0.10",
+    "@lavamoat/preinstall-always-fail": "^2.0.0"
+  },
+  "scripts": {
+    "build": "NODE_ENV=production LD_PKG=javascript webpack --config ../../webpack.production.js",
+    "build-demo-watch": "while true; do npm run build-demo; sleep 1; done",
+    "build-demo": "../../node_modules/.bin/esbuild demo/index.js --bundle --outfile=demo/build/index.js --allow-overwrite --target=es2020",
+    "demo": "npm run build-demo && serve ./demo -l 3000",
+    "test": "npm run demo & npm run test-chrome && npm run test-firefox && npm run test-safari",
+    "test-chrome": "../../node_modules/.bin/wdio run chrome.wdio.conf.js",
+    "test-safari": "../../node_modules/.bin/wdio run safari.wdio.conf.js",
+    "test-firefox": "../../node_modules/.bin/wdio run firefox.wdio.conf.js"
+  },
+  "lavamoat": {
+    "allowScripts": {
+      "@lavamoat/preinstall-always-fail": false
     }
+  }
 }

--- a/packages/react/.npmrc
+++ b/packages/react/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,40 +1,47 @@
 {
-    "name": "@lavamoat/lavadome-react",
-    "version": "0.0.10",
-    "description": "",
-    "license": "MIT",
-    "module": "src/index.mjs",
-    "main": "build/main.js",
-    "scripts": {
-        "test": "npm run dev & (npm run test-chrome && npm run test-firefox && npm run test-safari)",
-        "test-chrome": "../../node_modules/.bin/wdio run chrome.wdio.conf.js",
-        "test-safari": "../../node_modules/.bin/wdio run safari.wdio.conf.js",
-        "test-firefox": "../../node_modules/.bin/wdio run firefox.wdio.conf.js",
-        "build": "NODE_ENV=production LD_PKG=react webpack --config ../../webpack.production.js",
-        "dev": "NODE_ENV=development LD_PKG=react webpack serve --config webpack.development.js"
-    },
-    "devDependencies": {
-        "@babel/core": "^7.23.6",
-        "@swc/core": "^1.3.101",
-        "@swc/helpers": "^0.5.3",
-        "@testing-library/react": "^12.1.2",
-        "babel-loader": "^8.2.2",
-        "css-loader": "^6.8.1",
-        "html-loader": "^4.2.0",
-        "html-webpack-plugin": "^5.6.0",
-        "jsdom": "^23.0.1",
-        "jsdom-global": "^3.0.2",
-        "react-refresh": "^0.14.0",
-        "swc-loader": "^0.2.3",
-        "webpack": "^5.89.0",
-        "webpack-cli": "^5.1.4",
-        "webpack-dev-server": "4.15.1"
-    },
-    "dependencies": {
-        "@lavamoat/lavadome-core": "^0.0.10"
-    },
-    "peerDependencies": {
-        "react": "^16.12.0",
-        "react-dom": "^16.12.0"
+  "name": "@lavamoat/lavadome-react",
+  "version": "0.0.10",
+  "description": "",
+  "license": "MIT",
+  "module": "src/index.mjs",
+  "main": "build/main.js",
+  "scripts": {
+    "test": "npm run dev & (npm run test-chrome && npm run test-firefox && npm run test-safari)",
+    "test-chrome": "../../node_modules/.bin/wdio run chrome.wdio.conf.js",
+    "test-safari": "../../node_modules/.bin/wdio run safari.wdio.conf.js",
+    "test-firefox": "../../node_modules/.bin/wdio run firefox.wdio.conf.js",
+    "build": "NODE_ENV=production LD_PKG=react webpack --config ../../webpack.production.js",
+    "dev": "NODE_ENV=development LD_PKG=react webpack serve --config webpack.development.js"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.23.6",
+    "@swc/core": "^1.3.101",
+    "@swc/helpers": "^0.5.3",
+    "@testing-library/react": "^12.1.2",
+    "babel-loader": "^8.2.2",
+    "css-loader": "^6.8.1",
+    "html-loader": "^4.2.0",
+    "html-webpack-plugin": "^5.6.0",
+    "jsdom": "^23.0.1",
+    "jsdom-global": "^3.0.2",
+    "react-refresh": "^0.14.0",
+    "swc-loader": "^0.2.3",
+    "webpack": "^5.89.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "4.15.1"
+  },
+  "dependencies": {
+    "@lavamoat/lavadome-core": "^0.0.10",
+    "@lavamoat/preinstall-always-fail": "^2.0.0"
+  },
+  "peerDependencies": {
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
+  },
+  "lavamoat": {
+    "allowScripts": {
+      "@lavamoat/preinstall-always-fail": false,
+      "@swc/core": false
     }
+  }
 }


### PR DESCRIPTION
attempt to add [@lavamoat/allow-scripts](https://github.com/LavaMoat/LavaMoat/tree/main/packages/allow-scripts) protection.

I verified LD works as before by cloning LD on this branch, installing and building all packages successfully