### PR TITLE
React and React-DOM deps should be dev-deps as well as peer-deps

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,7 +32,9 @@
     "swc-loader": "^0.2.3",
     "webpack": "^5.89.0",
     "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "4.15.1"
+    "webpack-dev-server": "4.15.1",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   },
   "dependencies": {
     "@lavamoat/lavadome-core": "^0.0.11",


### PR DESCRIPTION
ctx https://github.com/LavaMoat/LavaDome/pull/23/files#r1461562336

having those as peer-deps is great for LavaDome to be easily integrated as a dependency for other projects, but for LavaDome to work locally for development too, they must be listed as dev-deps as well (AFAIU)