### PR TITLE
Replace Envelope mechanizm from object to string based to avoid infinite React rerendering

### DIFF
--- a/packages/core/src/lavadome.mjs
+++ b/packages/core/src/lavadome.mjs
@@ -26,7 +26,7 @@ export function LavaDome(host, opts) {
     function text(text) {
         if (typeof text !== 'string') {
             throw new Error(
-                `LavaDome: first argument must be a string, instead got ${stringify(text)}`);
+                `LavaDomeCore: first argument must be a string, instead got ${stringify(text)}`);
         }
 
         // check if text is a single char and if so, either is part of a longer secret

--- a/packages/core/src/native.mjs
+++ b/packages/core/src/native.mjs
@@ -4,7 +4,7 @@ const {
     Object, Array,
     Function, Math,
     parseInt, WeakMap,
-    Error, JSON, Symbol,
+    Error, JSON, crypto,
 } = globalThis;
 const {
     defineProperties, assign,
@@ -14,6 +14,7 @@ const {
 const { from } = Array;
 const {random } = Math;
 const { stringify } = JSON;
+const randomUUID = crypto.randomUUID.bind(crypto);
 
 // native generation util
 const n = (obj, prop, accessor) =>
@@ -31,7 +32,6 @@ export const keys = n(globalThis?.Array?.prototype, 'keys', 'value');
 export const at = n(globalThis?.Array?.prototype, 'at', 'value');
 export const get = n(globalThis?.WeakMap?.prototype, 'get', 'value');
 export const set = n(globalThis?.WeakMap?.prototype, 'set', 'value');
-export const has = n(globalThis?.WeakMap?.prototype, 'has', 'value');
 export const toFixed = n(globalThis?.Number?.prototype, 'toFixed', 'value')
 
 export {
@@ -39,7 +39,7 @@ export {
     Object, Array,
     Function, Math,
     parseInt, WeakMap,
-    Error, JSON, Symbol,
+    Error, JSON, crypto,
     // Object
     defineProperties, assign,
     getOwnPropertyDescriptor,
@@ -50,4 +50,6 @@ export {
     random,
     // JSON
     stringify,
+    // crypto
+    randomUUID,
 }

--- a/packages/javascript/src/index.mjs
+++ b/packages/javascript/src/index.mjs
@@ -1,2 +1,4 @@
+'use strict';
+
 import { LavaDome as LavaDomeCore } from "@lavamoat/lavadome-core"
 export class LavaDome extends LavaDomeCore {}

--- a/packages/react/src/index.jsx
+++ b/packages/react/src/index.jsx
@@ -1,57 +1,7 @@
-import React, { useEffect, useRef } from 'react'
-import { LavaDome as LavaDomeCore } from "@lavamoat/lavadome-core"
-import {WeakMap, get, set, has, Symbol} from "../../core/src/native.mjs"
+'use strict';
 
-// WeakMap{ unique-token -> sensitive-text }
-// Only code with access to this map can exchange a token with a text
-const tokens = new WeakMap();
+import {LavaDome} from "./lavadome";
+export {LavaDome};
 
-// weakly map sensitive text of the user with a unique token representing it, so that
-// the token is the one being passed around React internals rather than the sensitive text
-export const toLavaDomeToken = text => {
-    const lavadome = Symbol();
-    set(tokens, lavadome, text);
-    return lavadome;
-}
-
-export const LavaDome = ({ text, unsafeOpenModeShadow }) => {
-    // variable @text is named that way only for visibility - in reality it's a lavadome token
-    const token = text;
-
-    if (!has(tokens, token)) {
-        throw new Error(
-            'LavaDome: first argument must be a valid LavaDome token ' +
-            '(replace "text={\'secret\'}" with "text={toLavaDomeToken(\'secret\')}")');
-    }
-
-    const host = useRef(null);
-
-    return (
-        // form a span to act as the LavaDome host
-        <span ref={host}>
-            <LavaDomeShadow
-                host={host} token={token}
-                unsafeOpenModeShadow={unsafeOpenModeShadow}
-            />
-        </span>
-    );
-};
-
-function LavaDomeShadow({ host, token, unsafeOpenModeShadow }) {
-    const lavadome = useRef(null);
-
-    useEffect(() => {
-        // generate a lavadome instance reference
-        const opts = { unsafeOpenModeShadow };
-        lavadome.current = new LavaDomeCore(host.current, opts);
-        return () => lavadome.current = null;
-    }, []);
-
-    useEffect(() => {
-        // exchange token for sensitive text and update lavadome reference with it
-        const text = get(tokens, token);
-        lavadome.current.text(text);
-    }, [token]);
-
-    return <></>;
-}
+import {textToToken as toLavaDomeToken} from "./token.mjs";
+export {toLavaDomeToken};

--- a/packages/react/src/lavadome.jsx
+++ b/packages/react/src/lavadome.jsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useRef } from 'react'
+import { LavaDome as LavaDomeCore } from "@lavamoat/lavadome-core"
+import { tokenToText } from "./token.mjs";
+
+export const LavaDome = ({ text, unsafeOpenModeShadow }) => {
+    // variable @text is named that way only for visibility - in reality it's a lavadome token
+    const token = text, host = useRef(null);
+
+    return (
+        // form a span to act as the LavaDome host
+        <span ref={host}>
+            <LavaDomeShadow
+                host={host} token={token}
+                unsafeOpenModeShadow={unsafeOpenModeShadow}
+            />
+        </span>
+    );
+};
+
+function LavaDomeShadow({ host, token, unsafeOpenModeShadow }) {
+    // exchange token for sensitive text before check
+    const text = tokenToText(token);
+    const lavadome = useRef(null);
+
+    // generate a lavadome instance reference with a teardown
+    useEffect(() => {
+        const opts = { unsafeOpenModeShadow };
+        lavadome.current = new LavaDomeCore(host.current, opts);
+        return () => lavadome.current = null;
+    }, []);
+
+    // update lavadome secret text (given that the token is updated too)
+    useEffect(() => lavadome.current.text(text), [token]);
+
+    return <></>;
+}

--- a/packages/react/src/token.mjs
+++ b/packages/react/src/token.mjs
@@ -1,0 +1,36 @@
+import {create, hasOwn, randomUUID, stringify} from "@lavamoat/lavadome-core/src/native.mjs";
+
+const tokenToTextMap = create(null), textToTokenMap = create(null);
+
+// map given token back to the secret text, but do so safely by making
+// sure input is safe to access and use, as it comes from outside
+export function tokenToText(token) {
+    const text = tokenToTextMap[token];
+
+    const isTextValid = typeof text === 'string' && hasOwn(textToTokenMap, text);
+    const isTokenValid = typeof token === 'string' && hasOwn(tokenToTextMap, token);
+
+    if (!isTextValid || !isTokenValid) {
+        throw new Error(
+            'LavaDomeReact: first argument must be a valid LavaDome token ' +
+            '(replace "text={\'secret\'}" with "text={toLavaDomeToken(\'secret\')}")');
+    }
+
+    return text;
+}
+
+// map sensitive text of the user with a unique token representing it, so that the
+// token is the one being passed around React internals rather than the sensitive text
+export const textToToken = text => {
+    if (typeof text !== 'string') {
+        throw new Error(`LavaDomeReact: first argument must be a string, instead got ${stringify(text)}`);
+    }
+
+    if (!hasOwn(textToTokenMap, text)) {
+        const token = randomUUID();
+        textToTokenMap[text] = token;
+        tokenToTextMap[token] = text;
+    }
+
+    return textToTokenMap[text];
+}


### PR DESCRIPTION
In addition to minor lift-ups, this PR mainly focuses on a problem introduced at #26.

* At #26 we follow @naugtur's envelop idea from #23 where we export a util function to help developers pass a unique object reference (aka token) to map to the secret instead of the secret itself, so that we don't leak the actual secret text to React internals at any point (because those leak it to the global object which compromises LavaDome completely)
* Problem with this approach is that since the token is a new object, an identical secret text maps out to two different tokens, thus forcing React to rerender over and over even though the secret text is the same
* This PR replaces the mechanizm of object-based tokens with string based tokens, by leveraging builtin `crypto.randomUUID` API, so that it's easier and more efficient to map secrets to token, especially when the secrets might already be familiar to the internals of LavaDomeReact