### PR TITLE
Downgrade to unsafe random generation under testing envs

### DIFF
--- a/packages/core/src/native.mjs
+++ b/packages/core/src/native.mjs
@@ -14,7 +14,7 @@ const {
 const { from } = Array;
 const {random } = Math;
 const { stringify } = JSON;
-const randomUUID = crypto.randomUUID.bind(crypto);
+const randomUUID = crypto?.randomUUID?.bind(crypto);
 
 // native generation util
 const n = (obj, prop, accessor) =>

--- a/packages/react/src/lavadome.jsx
+++ b/packages/react/src/lavadome.jsx
@@ -19,7 +19,7 @@ export const LavaDome = ({ text, unsafeOpenModeShadow }) => {
 
 function LavaDomeShadow({ host, token, unsafeOpenModeShadow }) {
     // exchange token for sensitive text before check
-    const text = tokenToText(token);
+    const text = tokenToText(token, unsafeOpenModeShadow);
     const lavadome = useRef(null);
 
     // generate a lavadome instance reference with a teardown

--- a/packages/react/src/token.mjs
+++ b/packages/react/src/token.mjs
@@ -1,10 +1,31 @@
 import {create, hasOwn, randomUUID, stringify} from "@lavamoat/lavadome-core/src/native.mjs";
+import {OPTIONS} from "@lavamoat/lavadome-core/src/options.mjs";
 
 const tokenToTextMap = create(null), textToTokenMap = create(null);
 
+const rand = () => randomUUID ? randomUUID() :
+    // unsafe weak random generation - only meant for testing mode!
+    // (because "randomUUID" might not appear in testing envs such as node)
+    (Math.random() + 1).toString(36).substring(7);
+
 // map given token back to the secret text, but do so safely by making
 // sure input is safe to access and use, as it comes from outside
-export function tokenToText(token) {
+export function tokenToText(token, unsafeOpenModeShadow) {
+    if (!randomUUID) {
+        if (unsafeOpenModeShadow) {
+            console.warn('LavaDomeReact:',
+                `It seems that some API required for LavaDome to perform safely is missing ("crypto.randomUUID").`,
+                `Since option "${OPTIONS.unsafeOpenModeShadow}" is enabled,`,
+                `this should be fine, as testing environments are likely to not have support for such features.`,
+                `If this isn't a testing environment, there's something wrong with your LavaDome setup - this downgrades security!`
+            );
+        } else {
+            throw new Error(
+                `LavaDomeReact: this runtime environment does not seem to support some API required for LavaDome to perform safely ("crypto.randomUUID").`
+            );
+        }
+    }
+
     const text = tokenToTextMap[token];
 
     const isTextValid = typeof text === 'string' && hasOwn(textToTokenMap, text);
@@ -12,8 +33,8 @@ export function tokenToText(token) {
 
     if (!isTextValid || !isTokenValid) {
         throw new Error(
-            'LavaDomeReact: first argument must be a valid LavaDome token ' +
-            '(replace "text={\'secret\'}" with "text={toLavaDomeToken(\'secret\')}")');
+            `LavaDomeReact: first argument must be a valid LavaDome token ` +
+            `(replace "text={'secret'}" with "text={toLavaDomeToken('secret')}")`);
     }
 
     return text;
@@ -27,7 +48,7 @@ export const textToToken = text => {
     }
 
     if (!hasOwn(textToTokenMap, text)) {
-        const token = randomUUID();
+        const token = rand();
         textToTokenMap[text] = token;
         tokenToTextMap[token] = text;
     }


### PR DESCRIPTION
Following #29 where we introduced usage of `crypto.randomUUID`, we now have to make sure we downgrade to more native APIs when it isn't found - this seems to happen under non-browser testing infras such as nodejs emulators.
We want to allow those to still test with LavaDome, but to throw at production.