### PR TITLE
Safely remove potential React state leakage

### DIFF
--- a/packages/react/demo/App.jsx
+++ b/packages/react/demo/App.jsx
@@ -1,11 +1,16 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { LavaDome as LavaDomeReact, toLavaDomeToken } from '../src/index';
 
 const unsafeOpenModeShadow = location.href.includes('unsafeOpenModeShadow');
 
 export default function App() {
+    const [count, setCount] = useState(0);
+
+    console.info('render marked', count);
+
     return (
-        <div style={{ borderStyle: 'solid', margin: '10px', padding: '10px' }} >
+        <div onClick={() => setCount(count+1)}
+            style={{ borderStyle: 'solid', margin: '10px', padding: '10px' }} >
             <div>
                 This is not a secret:
                 <p id="PUBLIC">
@@ -21,6 +26,7 @@ export default function App() {
                     />
                 </p>
             </div>
+            <hr/><ul><li><i>(Click to force component rerender "{count}")</i></li></ul>
         </div>
     )
 }

--- a/packages/react/src/lavadome.jsx
+++ b/packages/react/src/lavadome.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { LavaDome as LavaDomeCore } from "@lavamoat/lavadome-core"
-import { tokenToText } from "./token.mjs";
+import {tokenToDep, tokenToText} from "./token.mjs";
 
 export const LavaDome = ({ text, unsafeOpenModeShadow }) => {
     // variable @text is named that way only for visibility - in reality it's a lavadome token
@@ -18,19 +18,23 @@ export const LavaDome = ({ text, unsafeOpenModeShadow }) => {
 };
 
 function LavaDomeShadow({ host, token, unsafeOpenModeShadow }) {
+    let lavadome;
+
     // exchange token for sensitive text before check
     const text = tokenToText(token, unsafeOpenModeShadow);
-    const lavadome = useRef(null);
 
     // generate a lavadome instance reference with a teardown
     useEffect(() => {
         const opts = { unsafeOpenModeShadow };
-        lavadome.current = new LavaDomeCore(host.current, opts);
-        return () => lavadome.current = null;
+        lavadome = new LavaDomeCore(host.current, opts);
+        return () => lavadome = null;
     }, []);
 
+    // use a unique and useless representation of the token as the useEffect dep
+    const dep = tokenToDep(token);
+
     // update lavadome secret text (given that the token is updated too)
-    useEffect(() => lavadome.current.text(text), [token]);
+    useEffect(() => lavadome.text(text), [dep]);
 
     return <></>;
 }


### PR DESCRIPTION
Following #23, #26, #29, #30 where we attempt to stop leaking sensitive information to React APIs (`useState`, `useRef`, `useEffect`, etc), this too addresses this problem by:

* Stop leaking the LavaDome instance via `useRef` and instead keep it in a local variable in scope
* Stop leaking the token as a `useEffect` dependency and instead replace it with a random useless matching identifier string (even though obtaining the token isn't really useful for attackers except for maybe being able to tell LavaDome what string to draw to screen - maybe)

Also, update demo app to easily trigger rerenders for tests