### PR TITLE
Fix navigation undefined bug

### DIFF
--- a/packages/core/src/lavadome.mjs
+++ b/packages/core/src/lavadome.mjs
@@ -19,7 +19,7 @@ import {distraction, loadable, hardened} from './element.mjs';
 import {getShadow} from './shadow.mjs';
 
 // text-fragments links can be abused to leak shadow internals - block in-app redirection to them
-navigation.addEventListener('navigate', event => {
+navigation?.addEventListener('navigate', event => {
     const dest = url(destination(event));
     if (includes(dest, ':~:')) {
         preventDefault(event);


### PR DESCRIPTION
navigation is undefined in Firefox (which is fine, because the protection that counts on this API is only relevant in Chrome)